### PR TITLE
Bump mountebank to 2.9.1 - aims to solve #9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM alpine:3.16.1
+FROM alpine:3.18.6
 
 EXPOSE 2525
 
 CMD ["mb"]
 
-ENV NODE_VERSION=16.16.0-r0 NPM_VERSION=8.10.0-r0
+ENV NODE_VERSION=18.20.1-r0 NPM_VERSION=9.6.6-r0
 
 RUN apk update \
  && apk add --no-cache nodejs=${NODE_VERSION} npm=${NPM_VERSION}
 
-ENV MOUNTEBANK_VERSION=2.7.0
+ENV MOUNTEBANK_VERSION=2.9.1
 
 RUN npm install -g mountebank@${MOUNTEBANK_VERSION} --production \
  && npm cache clean --force 2>/dev/null \


### PR DESCRIPTION
Bumped alpine to 3.16.1 - that's the latest supporting node 18.x ([bbyars latest uses 18.17.0](https://hub.docker.com/layers/bbyars/mountebank/2.9.1/images/sha256-c96d2c32af601b555af1af51be854930a2ccb21550978e708e1724a074fb3d77?context=explore)).

- node: 18.20.1-r0 
- npm 9.6.6-r0
- mountebank 2.9.1